### PR TITLE
Check if palette tiddler exists before using

### DIFF
--- a/tiddlywiki-codemirror-6/engine.js
+++ b/tiddlywiki-codemirror-6/engine.js
@@ -229,8 +229,11 @@ function CodeMirrorEngine(options) {
 	this.solarizedLightHighlightStyle = $tw.utils.codemirror.getSolarizedLightHighlightStyle(HighlightStyle,tags);
 	this.solarizedDarkHighlightStyle = $tw.utils.codemirror.getSolarizedDarkHighlightStyle(HighlightStyle,tags);
 
-	var solarizedTheme = this.widget.wiki.getTiddler(this.widget.wiki.getTiddlerText("$:/palette")).fields["color-scheme"] === "light" ? this.solarizedLightTheme : this.solarizedDarkTheme;
-	var solarizedHighlightStyle = this.widget.wiki.getTiddler(this.widget.wiki.getTiddlerText("$:/palette")).fields["color-scheme"] === "light" ? this.solarizedLightHighlightStyle : this.solarizedDarkHighlightStyle;
+	var palette = this.widget.wiki.getTiddlerText("$:/palette");
+	var paletteTiddler = palette && this.widget.wiki.getTiddler(palette);
+	
+	var solarizedTheme = !paletteTiddler || paletteTiddler.fields["color-scheme"] === "light" ? this.solarizedLightTheme : this.solarizedDarkTheme;
+	var solarizedHighlightStyle = !paletteTiddler || paletteTiddler.fields["color-scheme"] === "light" ? this.solarizedLightHighlightStyle : this.solarizedDarkHighlightStyle;
 
 	var autoCloseBrackets = this.widget.wiki.getTiddlerText("$:/config/codemirror-6/closeBrackets") === "yes";
 


### PR DESCRIPTION
I was running into some occasional crashing while trying to use this plugin, complaining of not being able to find `fields` of undefined on this line. I think another plugin I had installed (probably https://wikilabs.github.io/editions/palette-switcher/) was playing with the palette tiddler at startup, and maybe there was a race? Anyway, there didn't seem to be a downside to checking here before accessing the field. As a bonus we only get the tiddler once now.

I defaulted to the light theme in the case where we can't find the tiddler.

No prob if you're not interested, just wanted to share! Thanks for your work in making this plugin ❤️ 