### PR TITLE
Allow widget editClass to be undefined

### DIFF
--- a/tiddlywiki-codemirror-6/files/modules/subclasses/editor/edit-codemirror-6.js
+++ b/tiddlywiki-codemirror-6/files/modules/subclasses/editor/edit-codemirror-6.js
@@ -30,10 +30,10 @@ exports.prototype.render = function(parent,nextSibling) {
 	this.updateShortcutLists(this.getShortcutTiddlerList());
 	this.hasStylesheetTag = this.wiki.getTiddler(this.editTitle).hasTag("$:/tags/Stylesheet");
 	//this.engine.updateKeymaps();
-	var lineNumbers = this.wiki.getTiddlerText("$:/config/codemirror-6/lineNumbers") === "yes" && this.editClass.indexOf("tc-edit-texteditor-body") !== -1;
+	var lineNumbers = this.wiki.getTiddlerText("$:/config/codemirror-6/lineNumbers") === "yes" && this.editClass?.indexOf("tc-edit-texteditor-body") !== -1;
 	this.engine.toggleLineNumbers(lineNumbers);
 	this.engine.toggleFoldGutter(lineNumbers);
-	var highlightActiveLine = this.wiki.getTiddlerText("$:/config/codemirror-6/highlightActiveLine") === "yes" && this.editClass.indexOf("tc-edit-texteditor-body") !== -1;
+	var highlightActiveLine = this.wiki.getTiddlerText("$:/config/codemirror-6/highlightActiveLine") === "yes" && this.editClass?.indexOf("tc-edit-texteditor-body") !== -1;
 	this.engine.toggleHighlightActiveLine(highlightActiveLine);
 	this.engine.toggleHighlightActiveLineGutter(highlightActiveLine);
 	var autocorrect = this.wiki.getTiddlerText("$:/config/codemirror-6/autocorrect") === "yes";
@@ -155,12 +155,12 @@ exports.prototype.refresh = function(changedTiddlers) {
 		this.engine.toggleSpellcheck(spellcheck);
 	}
 	if(changedTiddlers["$:/config/codemirror-6/lineNumbers"]) {
-		var lineNumbers = this.wiki.getTiddlerText("$:/config/codemirror-6/lineNumbers") === "yes" && this.editClass.indexOf("tc-edit-texteditor-body") !== -1;
+		var lineNumbers = this.wiki.getTiddlerText("$:/config/codemirror-6/lineNumbers") === "yes" && this.editClass?.indexOf("tc-edit-texteditor-body") !== -1;
 		this.engine.toggleLineNumbers(lineNumbers);
 		this.engine.toggleFoldGutter(lineNumbers);
 	}
 	if(changedTiddlers["$:/config/codemirror-6/highlightActiveLine"]) {
-		var highlightActiveLine = this.wiki.getTiddlerText("$:/config/codemirror-6/highlightActiveLine") === "yes" && this.editClass.indexOf("tc-edit-texteditor-body") !== -1;
+		var highlightActiveLine = this.wiki.getTiddlerText("$:/config/codemirror-6/highlightActiveLine") === "yes" && this.editClass?.indexOf("tc-edit-texteditor-body") !== -1;
 		this.engine.toggleHighlightActiveLine(highlightActiveLine);
 		this.engine.toggleHighlightActiveLineGutter(highlightActiveLine);
 	}


### PR DESCRIPTION
Fixes https://github.com/BurningTreeC/tiddlywiki-codemirror-6/issues/4

Totally possible that there's a more elegant solution here, still new on the whole widget lifecycle, but this worked as a fix for me. Cheers!

PS I was also confused for a while by the name indicated at the top of the file, since I think it doesn't get used? and doesn't match the filename. Am I missing something or just a typo?
https://github.com/BurningTreeC/tiddlywiki-codemirror-6/blob/d95260f42f1aad6c9e192a04c1f2694ab4215c58/tiddlywiki-codemirror-6/files/modules/subclasses/editor/edit-codemirror-6.js#L2